### PR TITLE
test: add Jest logger setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "axios": "^1.6.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.0.0",
+    "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
   }
 }

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,64 @@
+import { Logger, LogLevel } from '../logger';
+
+describe('Logger', () => {
+  let logger: Logger;
+  let consoleLog: jest.SpyInstance;
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    logger = new Logger();
+    logger.setLevel(LogLevel.INFO);
+    consoleLog = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('writes info messages as structured JSON', () => {
+    logger.info('scan started', { target: 'https://example.com' });
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
+
+    const entry = JSON.parse(consoleLog.mock.calls[0][0]);
+    expect(entry).toEqual(
+      expect.objectContaining({
+        level: 'INFO',
+        message: 'scan started',
+        meta: { target: 'https://example.com' },
+      })
+    );
+    expect(Date.parse(entry.timestamp)).not.toBeNaN();
+  });
+
+  it('suppresses messages below the configured log level', () => {
+    logger.setLevel(LogLevel.WARN);
+
+    logger.debug('debug detail');
+    logger.info('informational detail');
+    logger.warn('warning detail');
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    const entry = JSON.parse(consoleLog.mock.calls[0][0]);
+    expect(entry.level).toBe('WARN');
+    expect(entry.message).toBe('warning detail');
+  });
+
+  it('routes error messages to console.error', () => {
+    logger.error('scan failed', { reason: 'connection refused' });
+
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledTimes(1);
+
+    const entry = JSON.parse(consoleError.mock.calls[0][0]);
+    expect(entry).toEqual(
+      expect.objectContaining({
+        level: 'ERROR',
+        message: 'scan failed',
+        meta: { reason: 'connection refused' },
+      })
+    );
+  });
+});

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add ts-jest configuration for TypeScript test execution in this ESM project
- add a Jest-specific tsconfig for test globals without changing the production build config
- cover logger JSON output, log-level filtering, and error routing with three focused tests

## Tests
- npm test

Closes #3