### PR TITLE
docs: add Claude Code MCP config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,126 @@ Claude Code MCP server for OWASP ZAP & Burp Suite — automated pentest recon, v
 git clone https://github.com/IN3PIRE/pentest-mcp
 cd pentest-mcp
 npm install
+npm run build
+```
 
-# Configure Claude Code
-# Add to your Claude Code MCP config:
+## Claude Code MCP Configuration
+
+The server reads these environment variables:
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `ZAP_API_KEY` | Recommended | none | API key for OWASP ZAP, if ZAP requires one. |
+| `BURP_API_KEY` | Recommended | none | API key for Burp Suite Enterprise or Burp API access. |
+| `ZAP_BASE_URL` | No | `http://localhost:8080` | Base URL for the local or remote ZAP API. |
+| `BURP_BASE_URL` | No | `http://localhost:8090` | Base URL for the local or remote Burp API. |
+
+The examples below are valid JSON, so they intentionally do not include inline comments. Replace the paths and API keys before using them.
+
+### Direct Config Values
+
+Use this approach when you want the Claude Code MCP config to define the server path and scanner settings directly.
+
+macOS or Linux:
+
+```json
 {
   "mcpServers": {
     "pentest": {
       "command": "node",
-      "args": ["/path/to/pentest-mcp/dist/index.js"],
+      "args": ["/Users/you/src/pentest-mcp/dist/index.js"],
       "env": {
-        "ZAP_API_KEY": "your-zap-key",
-        "BURP_API_KEY": "your-burp-key"
+        "ZAP_API_KEY": "replace-with-zap-api-key",
+        "BURP_API_KEY": "replace-with-burp-api-key",
+        "ZAP_BASE_URL": "http://localhost:8080",
+        "BURP_BASE_URL": "http://localhost:8090"
       }
     }
   }
 }
 ```
+
+Windows:
+
+```json
+{
+  "mcpServers": {
+    "pentest": {
+      "command": "node",
+      "args": ["C:\\Users\\you\\src\\pentest-mcp\\dist\\index.js"],
+      "env": {
+        "ZAP_API_KEY": "replace-with-zap-api-key",
+        "BURP_API_KEY": "replace-with-burp-api-key",
+        "ZAP_BASE_URL": "http://localhost:8080",
+        "BURP_BASE_URL": "http://localhost:8090"
+      }
+    }
+  }
+}
+```
+
+Field notes:
+
+- `command` starts Node.js.
+- `args` points to the compiled MCP server entrypoint. Run `npm run build` first so `dist/index.js` exists.
+- `env` passes scanner credentials and API base URLs to `src/index.ts`.
+- `ZAP_BASE_URL` and `BURP_BASE_URL` can be omitted if both tools use the local defaults.
+
+### Shell Environment Approach
+
+Use this approach when you prefer to keep scanner credentials in the shell environment instead of writing them into the MCP config.
+
+macOS or Linux shell setup:
+
+```bash
+export PENTEST_MCP_HOME="$HOME/src/pentest-mcp"
+export ZAP_API_KEY="replace-with-zap-api-key"
+export BURP_API_KEY="replace-with-burp-api-key"
+export ZAP_BASE_URL="http://localhost:8080"
+export BURP_BASE_URL="http://localhost:8090"
+```
+
+Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "pentest": {
+      "command": "bash",
+      "args": ["-lc", "node \"$PENTEST_MCP_HOME/dist/index.js\""]
+    }
+  }
+}
+```
+
+Windows PowerShell setup:
+
+```powershell
+$env:PENTEST_MCP_HOME = "C:\Users\you\src\pentest-mcp"
+$env:ZAP_API_KEY = "replace-with-zap-api-key"
+$env:BURP_API_KEY = "replace-with-burp-api-key"
+$env:ZAP_BASE_URL = "http://localhost:8080"
+$env:BURP_BASE_URL = "http://localhost:8090"
+```
+
+Claude Code config:
+
+```json
+{
+  "mcpServers": {
+    "pentest": {
+      "command": "powershell.exe",
+      "args": [
+        "-NoProfile",
+        "-Command",
+        "node \"$env:PENTEST_MCP_HOME\\dist\\index.js\""
+      ]
+    }
+  }
+}
+```
+
+When using the shell environment approach, launch Claude Code from the same environment that defines the variables, or move the values into the direct config form above.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Add a Claude Code MCP configuration section with direct macOS/Linux and Windows examples.
- Document the ZAP/Burp environment variables the server reads.
- Add shell-environment examples for users who prefer not to store scanner credentials in the MCP config.

## Validation
- Parsed all README fenced `json` blocks with `json.loads`.
- Ran `git diff --check`.
- `npm run build` was not run successfully because this checkout has no installed `tsc`; I kept this docs-only.

Closes #4.
